### PR TITLE
refactor(typescript): extract shared tsup/vitest config factories

### DIFF
--- a/sdks/typescript/config/tsup.base.ts
+++ b/sdks/typescript/config/tsup.base.ts
@@ -1,0 +1,96 @@
+import { defineConfig, type Options } from "tsup";
+
+interface TsupConfigOptions {
+  /** Entry points — object map or string array */
+  entry: Record<string, string> | string[];
+  /** Build target (default: "es2020") */
+  target?: string;
+  /** Packages to exclude from bundle */
+  external?: string[];
+  /** JS banner per format (e.g. shebang for CLI) */
+  banner?: { js?: string };
+  /** Use explicit file extensions: ESM → .mjs/.d.mts, CJS → .cjs/.d.cts */
+  explicitExtensions?: boolean;
+  /** Enable tree-shaking (default: false) */
+  treeshake?: boolean;
+  /** Disable code splitting (default: undefined, tsup decides) */
+  splitting?: boolean;
+  /** Use dts: true instead of dts: { resolve: true } (default: false) */
+  simpleDts?: boolean;
+  /** Disable sourcemaps (default: false — sourcemaps are ON by default) */
+  noSourcemap?: boolean;
+  /** ESM-only entry overrides (e.g. CLI bin entry only in ESM). If set, CJS uses `entry` and ESM uses this. */
+  esmEntry?: Record<string, string> | string[];
+}
+
+/**
+ * Create a standard dual ESM+CJS tsup config.
+ *
+ * Produces two builds:
+ *   - ESM → dist/esm (clean: true)
+ *   - CJS → dist/cjs (clean: false)
+ *
+ * @example Simple single-entry package
+ * ```ts
+ * import { createTsupConfig } from "../../config/tsup.base";
+ * export default createTsupConfig({ entry: { index: "src/index.ts" } });
+ * ```
+ *
+ * @example Multi-entry mechanism package
+ * ```ts
+ * export default createTsupConfig({
+ *   entry: {
+ *     index: "src/index.ts",
+ *     "exact/client/index": "src/exact/client/index.ts",
+ *   },
+ * });
+ * ```
+ */
+export function createTsupConfig(options: TsupConfigOptions) {
+  const {
+    entry,
+    target = "es2020",
+    external,
+    banner,
+    explicitExtensions = false,
+    treeshake,
+    splitting,
+    simpleDts = false,
+    noSourcemap = false,
+    esmEntry,
+  } = options;
+
+  const shared: Partial<Options> = {
+    dts: simpleDts ? true : { resolve: true },
+    sourcemap: !noSourcemap,
+    ...(target && { target }),
+    ...(external && { external }),
+    ...(treeshake !== undefined && { treeshake }),
+    ...(splitting !== undefined && { splitting }),
+  };
+
+  const esmConfig: Options = {
+    ...shared,
+    entry: esmEntry ?? entry,
+    format: ["esm"],
+    outDir: "dist/esm",
+    clean: true,
+    ...(banner && { banner }),
+    ...(explicitExtensions && {
+      outExtension: () => ({ js: ".mjs", dts: ".d.mts" }),
+    }),
+  };
+
+  const cjsConfig: Options = {
+    ...shared,
+    entry,
+    format: ["cjs"],
+    outDir: "dist/cjs",
+    clean: false,
+    ...(explicitExtensions && {
+      outExtension: () => ({ js: ".cjs", dts: ".d.cts" }),
+    }),
+  };
+
+  return defineConfig([esmConfig, cjsConfig]);
+}

--- a/sdks/typescript/config/vitest.base.ts
+++ b/sdks/typescript/config/vitest.base.ts
@@ -1,0 +1,121 @@
+import { loadEnv } from "vite";
+import { defineConfig } from "vitest/config";
+import tsconfigPaths from "vite-tsconfig-paths";
+
+interface VitestConfigOptions {
+  /** Exclude integration tests from default run */
+  excludeIntegration?: boolean;
+  /** Custom exclude patterns (overrides default excludeIntegration behavior) */
+  exclude?: string[];
+  /** Enable v8 coverage reporting */
+  coverage?: boolean;
+  /** Custom coverage include patterns (default: general config file excludes) */
+  coverageInclude?: string[];
+  /** Custom coverage exclude patterns */
+  coverageExclude?: string[];
+  /** Test pool (default: vitest decides; use "forks" for isolation) */
+  pool?: "threads" | "forks";
+  /** Enable vitest globals (describe, it, expect without imports) */
+  globals?: boolean;
+  /** Set test environment (e.g. "node") */
+  environment?: string;
+  /** Custom test include patterns */
+  include?: string[];
+  /** Path aliases for cross-package resolution in tests */
+  aliases?: Record<string, string>;
+  /** Skip loadEnv — some packages don't need environment variable loading */
+  noLoadEnv?: boolean;
+  /** Skip vite-tsconfig-paths plugin */
+  noTsconfigPaths?: boolean;
+  /** Setup files to run before tests */
+  setupFiles?: string[];
+}
+
+/**
+ * Create a standard vitest config.
+ *
+ * By default includes env loading via loadEnv and tsconfig path resolution.
+ *
+ * @example Standard config (most packages)
+ * ```ts
+ * import { createVitestConfig } from "../../config/vitest.base";
+ * export default createVitestConfig();
+ * ```
+ *
+ * @example With integration test exclusion
+ * ```ts
+ * export default createVitestConfig({ excludeIntegration: true });
+ * ```
+ *
+ * @example Mechanism package with coverage
+ * ```ts
+ * export default createVitestConfig({
+ *   noLoadEnv: true,
+ *   noTsconfigPaths: true,
+ *   globals: true,
+ *   environment: "node",
+ *   include: ["test/*.test.ts"],
+ *   excludeIntegration: true,
+ *   coverage: true,
+ *   coverageInclude: ["src/*.ts"],
+ *   coverageExclude: ["src/*.d.ts"],
+ * });
+ * ```
+ */
+export function createVitestConfig(options?: VitestConfigOptions) {
+  const {
+    excludeIntegration = false,
+    exclude,
+    coverage = false,
+    coverageInclude,
+    coverageExclude,
+    pool,
+    globals,
+    environment,
+    include,
+    aliases,
+    noLoadEnv = false,
+    noTsconfigPaths = false,
+    setupFiles,
+  } = options ?? {};
+
+  const resolvedExclude = exclude
+    ? exclude
+    : excludeIntegration
+      ? ["**/node_modules/**", "**/dist/**", "**/test/integrations/**"]
+      : undefined;
+
+  const defaultCoverageExclude = [
+    "node_modules/**",
+    "dist/**",
+    "test/**",
+    "**/*.config.ts",
+    "**/*.d.ts",
+  ];
+
+  return defineConfig(({ mode }) => ({
+    ...(aliases && {
+      resolve: { alias: aliases },
+    }),
+    test: {
+      ...(!noLoadEnv && { env: loadEnv(mode, process.cwd(), "") }),
+      ...(resolvedExclude && { exclude: resolvedExclude }),
+      ...(pool && { pool }),
+      ...(globals && { globals }),
+      ...(environment && { environment }),
+      ...(include && { include }),
+      ...(setupFiles && { setupFiles }),
+      ...(coverage && {
+        coverage: {
+          provider: "v8" as const,
+          reporter: ["text", "json", "html"],
+          ...(coverageInclude && { include: coverageInclude }),
+          exclude: coverageExclude ?? defaultCoverageExclude,
+        },
+      }),
+    },
+    ...(!noTsconfigPaths && {
+      plugins: [tsconfigPaths({ projects: ["."] })],
+    }),
+  }));
+}

--- a/sdks/typescript/packages/a2a/tsup.config.ts
+++ b/sdks/typescript/packages/a2a/tsup.config.ts
@@ -1,24 +1,8 @@
-import { defineConfig } from "tsup";
+import { createTsupConfig } from "../../config/tsup.base";
 
-export default defineConfig([
-  {
-    entry: ["src/index.ts", "src/client.ts", "src/server.ts"],
-    format: ["esm"],
-    dts: true,
-    clean: true,
-    outDir: "dist/esm",
-    outExtension() {
-      return { js: ".mjs", dts: ".d.mts" };
-    },
-  },
-  {
-    entry: ["src/index.ts", "src/client.ts", "src/server.ts"],
-    format: ["cjs"],
-    dts: true,
-    clean: false,
-    outDir: "dist/cjs",
-    outExtension() {
-      return { js: ".cjs", dts: ".d.cts" };
-    },
-  },
-]);
+export default createTsupConfig({
+  entry: ["src/index.ts", "src/client.ts", "src/server.ts"],
+  simpleDts: true,
+  noSourcemap: true,
+  explicitExtensions: true,
+});

--- a/sdks/typescript/packages/a2a/vitest.config.ts
+++ b/sdks/typescript/packages/a2a/vitest.config.ts
@@ -1,24 +1,16 @@
-import { defineConfig } from "vitest/config";
-import tsconfigPaths from "vite-tsconfig-paths";
 import { resolve } from "path";
+import { createVitestConfig } from "../../config/vitest.base";
 
-export default defineConfig({
-  plugins: [tsconfigPaths()],
-  resolve: {
-    alias: {
-      "@t402/core/types": resolve(__dirname, "../core/src/types"),
-      "@t402/core/server": resolve(__dirname, "../core/src/server"),
-      "@t402/core": resolve(__dirname, "../core/src"),
-    },
-  },
-  test: {
-    globals: true,
-    environment: "node",
-    pool: "forks",
-    include: ["test/**/*.test.ts"],
-    coverage: {
-      provider: "v8",
-      reporter: ["text", "json", "html"],
-    },
+export default createVitestConfig({
+  noLoadEnv: true,
+  globals: true,
+  environment: "node",
+  pool: "forks",
+  include: ["test/**/*.test.ts"],
+  coverage: true,
+  aliases: {
+    "@t402/core/types": resolve(__dirname, "../core/src/types"),
+    "@t402/core/server": resolve(__dirname, "../core/src/server"),
+    "@t402/core": resolve(__dirname, "../core/src"),
   },
 });

--- a/sdks/typescript/packages/cli/tsup.config.ts
+++ b/sdks/typescript/packages/cli/tsup.config.ts
@@ -1,26 +1,8 @@
-import { defineConfig } from "tsup";
+import { createTsupConfig } from "../../config/tsup.base";
 
-export default defineConfig([
-  {
-    entry: { index: "src/index.ts", bin: "src/bin.ts" },
-    format: ["esm"],
-    outDir: "dist/esm",
-    external: ["@t402/wdk", "@t402/wdk-gasless"],
-    dts: true,
-    sourcemap: true,
-    clean: true,
-    target: "es2020",
-    banner: {
-      js: "#!/usr/bin/env node",
-    },
-  },
-  {
-    entry: { index: "src/index.ts" },
-    format: ["cjs"],
-    outDir: "dist/cjs",
-    external: ["@t402/wdk", "@t402/wdk-gasless"],
-    dts: true,
-    sourcemap: true,
-    target: "es2020",
-  },
-]);
+export default createTsupConfig({
+  entry: { index: "src/index.ts" },
+  esmEntry: { index: "src/index.ts", bin: "src/bin.ts" },
+  external: ["@t402/wdk", "@t402/wdk-gasless"],
+  banner: { js: "#!/usr/bin/env node" },
+});

--- a/sdks/typescript/packages/core/tsup.config.ts
+++ b/sdks/typescript/packages/core/tsup.config.ts
@@ -1,6 +1,6 @@
-import { defineConfig } from "tsup";
+import { createTsupConfig } from "../../config/tsup.base";
 
-const baseConfig = {
+export default createTsupConfig({
   entry: {
     index: "src/index.ts",
     "client/index": "src/client/index.ts",
@@ -11,24 +11,4 @@ const baseConfig = {
     "types/v1/index": "src/types/v1/index.ts",
     "utils/index": "src/utils/index.ts",
   },
-  dts: {
-    resolve: true,
-  },
-  sourcemap: true,
-  target: "es2020",
-};
-
-export default defineConfig([
-  {
-    ...baseConfig,
-    format: "esm",
-    outDir: "dist/esm",
-    clean: true,
-  },
-  {
-    ...baseConfig,
-    format: "cjs",
-    outDir: "dist/cjs",
-    clean: false,
-  },
-]);
+});

--- a/sdks/typescript/packages/core/vitest.config.ts
+++ b/sdks/typescript/packages/core/vitest.config.ts
@@ -1,10 +1,3 @@
-import { loadEnv } from "vite";
-import { defineConfig } from "vitest/config";
-import tsconfigPaths from "vite-tsconfig-paths";
+import { createVitestConfig } from "../../config/vitest.base";
 
-export default defineConfig(({ mode }) => ({
-  test: {
-    env: loadEnv(mode, process.cwd(), ""),
-  },
-  plugins: [tsconfigPaths({ projects: ["."] })],
-}));
+export default createVitestConfig();

--- a/sdks/typescript/packages/erc8004/tsup.config.ts
+++ b/sdks/typescript/packages/erc8004/tsup.config.ts
@@ -1,24 +1,8 @@
-import { defineConfig } from "tsup";
+import { createTsupConfig } from "../../config/tsup.base";
 
-export default defineConfig([
-  {
-    entry: ["src/index.ts"],
-    format: ["esm"],
-    dts: true,
-    clean: true,
-    outDir: "dist/esm",
-    outExtension() {
-      return { js: ".mjs", dts: ".d.mts" };
-    },
-  },
-  {
-    entry: ["src/index.ts"],
-    format: ["cjs"],
-    dts: true,
-    clean: false,
-    outDir: "dist/cjs",
-    outExtension() {
-      return { js: ".cjs", dts: ".d.cts" };
-    },
-  },
-]);
+export default createTsupConfig({
+  entry: ["src/index.ts"],
+  simpleDts: true,
+  noSourcemap: true,
+  explicitExtensions: true,
+});

--- a/sdks/typescript/packages/erc8004/vitest.config.ts
+++ b/sdks/typescript/packages/erc8004/vitest.config.ts
@@ -1,25 +1,15 @@
-import { defineConfig } from "vitest/config";
-import tsconfigPaths from "vite-tsconfig-paths";
 import { resolve } from "path";
+import { createVitestConfig } from "../../config/vitest.base";
 
-export default defineConfig({
-  plugins: [tsconfigPaths()],
-  resolve: {
-    alias: {
-      "@t402/core/types": resolve(__dirname, "../core/src/types"),
-      "@t402/core/client": resolve(__dirname, "../core/src/client"),
-      "@t402/core/server": resolve(__dirname, "../core/src/server"),
-      "@t402/core": resolve(__dirname, "../core/src"),
-    },
-  },
-  test: {
-    globals: true,
-    environment: "node",
-    pool: "forks",
-    include: ["test/**/*.test.ts"],
-    coverage: {
-      provider: "v8",
-      reporter: ["text", "json", "html"],
-    },
+export default createVitestConfig({
+  globals: true,
+  pool: "forks",
+  coverage: true,
+  include: ["test/**/*.test.ts"],
+  aliases: {
+    "@t402/core/types": resolve(__dirname, "../core/src/types"),
+    "@t402/core/client": resolve(__dirname, "../core/src/client"),
+    "@t402/core/server": resolve(__dirname, "../core/src/server"),
+    "@t402/core": resolve(__dirname, "../core/src"),
   },
 });

--- a/sdks/typescript/packages/extensions/tsup.config.ts
+++ b/sdks/typescript/packages/extensions/tsup.config.ts
@@ -1,6 +1,6 @@
-import { defineConfig } from "tsup";
+import { createTsupConfig } from "../../config/tsup.base";
 
-const baseConfig = {
+export default createTsupConfig({
   entry: {
     index: "src/index.ts",
     "bazaar/index": "src/bazaar/index.ts",
@@ -9,24 +9,4 @@ const baseConfig = {
     "eip2612-gas-sponsoring/index": "src/eip2612-gas-sponsoring/index.ts",
     "erc20-approval-gas-sponsoring/index": "src/erc20-approval-gas-sponsoring/index.ts",
   },
-  dts: {
-    resolve: true,
-  },
-  sourcemap: true,
-  target: "es2020",
-};
-
-export default defineConfig([
-  {
-    ...baseConfig,
-    format: "esm",
-    outDir: "dist/esm",
-    clean: true,
-  },
-  {
-    ...baseConfig,
-    format: "cjs",
-    outDir: "dist/cjs",
-    clean: false,
-  },
-]);
+});

--- a/sdks/typescript/packages/extensions/vitest.config.ts
+++ b/sdks/typescript/packages/extensions/vitest.config.ts
@@ -1,15 +1,3 @@
-import { loadEnv } from "vite";
-import { defineConfig } from "vitest/config";
-import tsconfigPaths from "vite-tsconfig-paths";
+import { createVitestConfig } from "../../config/vitest.base";
 
-export default defineConfig(({ mode }) => ({
-  test: {
-    env: loadEnv(mode, process.cwd(), ""),
-    coverage: {
-      provider: "v8",
-      reporter: ["text", "json", "html"],
-      exclude: ["node_modules/**", "dist/**", "test/**", "**/*.config.ts", "**/*.d.ts"],
-    },
-  },
-  plugins: [tsconfigPaths({ projects: ["."] })],
-}));
+export default createVitestConfig({ coverage: true });

--- a/sdks/typescript/packages/http/axios/tsup.config.ts
+++ b/sdks/typescript/packages/http/axios/tsup.config.ts
@@ -1,27 +1,6 @@
-import { defineConfig } from "tsup";
+import { createTsupConfig } from "../../../config/tsup.base";
 
-const baseConfig = {
-  entry: {
-    index: "src/index.ts",
-  },
-  dts: {
-    resolve: true,
-  },
-  sourcemap: true,
+export default createTsupConfig({
+  entry: { index: "src/index.ts" },
   target: "node16",
-};
-
-export default defineConfig([
-  {
-    ...baseConfig,
-    format: "esm",
-    outDir: "dist/esm",
-    clean: true,
-  },
-  {
-    ...baseConfig,
-    format: "cjs",
-    outDir: "dist/cjs",
-    clean: false,
-  },
-]);
+});

--- a/sdks/typescript/packages/http/axios/vitest.config.ts
+++ b/sdks/typescript/packages/http/axios/vitest.config.ts
@@ -1,10 +1,3 @@
-import { loadEnv } from "vite";
-import { defineConfig } from "vitest/config";
-import tsconfigPaths from "vite-tsconfig-paths";
+import { createVitestConfig } from "../../../config/vitest.base";
 
-export default defineConfig(({ mode }) => ({
-  test: {
-    env: loadEnv(mode, process.cwd(), ""),
-  },
-  plugins: [tsconfigPaths({ projects: ["."] })],
-}));
+export default createVitestConfig();

--- a/sdks/typescript/packages/http/express/tsup.config.ts
+++ b/sdks/typescript/packages/http/express/tsup.config.ts
@@ -1,27 +1,6 @@
-import { defineConfig } from "tsup";
+import { createTsupConfig } from "../../../config/tsup.base";
 
-const baseConfig = {
-  entry: {
-    index: "src/index.ts",
-  },
-  dts: {
-    resolve: true,
-  },
-  sourcemap: true,
+export default createTsupConfig({
+  entry: { index: "src/index.ts" },
   target: "node16",
-};
-
-export default defineConfig([
-  {
-    ...baseConfig,
-    format: "esm",
-    outDir: "dist/esm",
-    clean: true,
-  },
-  {
-    ...baseConfig,
-    format: "cjs",
-    outDir: "dist/cjs",
-    clean: false,
-  },
-]);
+});

--- a/sdks/typescript/packages/http/express/vitest.config.ts
+++ b/sdks/typescript/packages/http/express/vitest.config.ts
@@ -1,10 +1,3 @@
-import { loadEnv } from "vite";
-import { defineConfig } from "vitest/config";
-import tsconfigPaths from "vite-tsconfig-paths";
+import { createVitestConfig } from "../../../config/vitest.base";
 
-export default defineConfig(({ mode }) => ({
-  test: {
-    env: loadEnv(mode, process.cwd(), ""),
-  },
-  plugins: [tsconfigPaths({ projects: ["."] })],
-}));
+export default createVitestConfig();

--- a/sdks/typescript/packages/http/facilitator-embedded/tsup.config.ts
+++ b/sdks/typescript/packages/http/facilitator-embedded/tsup.config.ts
@@ -1,27 +1,6 @@
-import { defineConfig } from "tsup";
+import { createTsupConfig } from "../../../config/tsup.base";
 
-const baseConfig = {
-  entry: {
-    index: "src/index.ts",
-  },
-  dts: {
-    resolve: true,
-  },
-  sourcemap: true,
+export default createTsupConfig({
+  entry: { index: "src/index.ts" },
   target: "node16",
-};
-
-export default defineConfig([
-  {
-    ...baseConfig,
-    format: "esm",
-    outDir: "dist/esm",
-    clean: true,
-  },
-  {
-    ...baseConfig,
-    format: "cjs",
-    outDir: "dist/cjs",
-    clean: false,
-  },
-]);
+});

--- a/sdks/typescript/packages/http/facilitator-embedded/vitest.config.ts
+++ b/sdks/typescript/packages/http/facilitator-embedded/vitest.config.ts
@@ -1,10 +1,3 @@
-import { loadEnv } from "vite";
-import { defineConfig } from "vitest/config";
-import tsconfigPaths from "vite-tsconfig-paths";
+import { createVitestConfig } from "../../../config/vitest.base";
 
-export default defineConfig(({ mode }) => ({
-  test: {
-    env: loadEnv(mode, process.cwd(), ""),
-  },
-  plugins: [tsconfigPaths({ projects: ["."] })],
-}));
+export default createVitestConfig();

--- a/sdks/typescript/packages/http/fastify/tsup.config.ts
+++ b/sdks/typescript/packages/http/fastify/tsup.config.ts
@@ -1,27 +1,6 @@
-import { defineConfig } from 'tsup'
+import { createTsupConfig } from "../../../config/tsup.base";
 
-const baseConfig = {
-  entry: {
-    index: 'src/index.ts',
-  },
-  dts: {
-    resolve: true,
-  },
-  sourcemap: true,
-  target: 'node16',
-}
-
-export default defineConfig([
-  {
-    ...baseConfig,
-    format: 'esm',
-    outDir: 'dist/esm',
-    clean: true,
-  },
-  {
-    ...baseConfig,
-    format: 'cjs',
-    outDir: 'dist/cjs',
-    clean: false,
-  },
-])
+export default createTsupConfig({
+  entry: { index: "src/index.ts" },
+  target: "node16",
+});

--- a/sdks/typescript/packages/http/fastify/vitest.config.ts
+++ b/sdks/typescript/packages/http/fastify/vitest.config.ts
@@ -1,10 +1,7 @@
-import { defineConfig } from 'vitest/config'
-import tsconfigPaths from 'vite-tsconfig-paths'
+import { createVitestConfig } from "../../../config/vitest.base";
 
-export default defineConfig({
-  plugins: [tsconfigPaths({ projects: ['.'] })],
-  test: {
-    globals: true,
-    environment: 'node',
-  },
-})
+export default createVitestConfig({
+  noLoadEnv: true,
+  globals: true,
+  environment: "node",
+});

--- a/sdks/typescript/packages/http/fetch/tsup.config.ts
+++ b/sdks/typescript/packages/http/fetch/tsup.config.ts
@@ -1,27 +1,6 @@
-import { defineConfig } from "tsup";
+import { createTsupConfig } from "../../../config/tsup.base";
 
-const baseConfig = {
-  entry: {
-    index: "src/index.ts",
-  },
-  dts: {
-    resolve: true,
-  },
-  sourcemap: true,
+export default createTsupConfig({
+  entry: { index: "src/index.ts" },
   target: "node16",
-};
-
-export default defineConfig([
-  {
-    ...baseConfig,
-    format: "esm",
-    outDir: "dist/esm",
-    clean: true,
-  },
-  {
-    ...baseConfig,
-    format: "cjs",
-    outDir: "dist/cjs",
-    clean: false,
-  },
-]);
+});

--- a/sdks/typescript/packages/http/fetch/vitest.config.ts
+++ b/sdks/typescript/packages/http/fetch/vitest.config.ts
@@ -1,10 +1,3 @@
-import { loadEnv } from "vite";
-import { defineConfig } from "vitest/config";
-import tsconfigPaths from "vite-tsconfig-paths";
+import { createVitestConfig } from "../../../config/vitest.base";
 
-export default defineConfig(({ mode }) => ({
-  test: {
-    env: loadEnv(mode, process.cwd(), ""),
-  },
-  plugins: [tsconfigPaths({ projects: ["."] })],
-}));
+export default createVitestConfig();

--- a/sdks/typescript/packages/http/hono/tsup.config.ts
+++ b/sdks/typescript/packages/http/hono/tsup.config.ts
@@ -1,27 +1,6 @@
-import { defineConfig } from "tsup";
+import { createTsupConfig } from "../../../config/tsup.base";
 
-const baseConfig = {
-  entry: {
-    index: "src/index.ts",
-  },
-  dts: {
-    resolve: true,
-  },
-  sourcemap: true,
+export default createTsupConfig({
+  entry: { index: "src/index.ts" },
   target: "node16",
-};
-
-export default defineConfig([
-  {
-    ...baseConfig,
-    format: "esm",
-    outDir: "dist/esm",
-    clean: true,
-  },
-  {
-    ...baseConfig,
-    format: "cjs",
-    outDir: "dist/cjs",
-    clean: false,
-  },
-]);
+});

--- a/sdks/typescript/packages/http/hono/vitest.config.ts
+++ b/sdks/typescript/packages/http/hono/vitest.config.ts
@@ -1,10 +1,3 @@
-import { loadEnv } from "vite";
-import { defineConfig } from "vitest/config";
-import tsconfigPaths from "vite-tsconfig-paths";
+import { createVitestConfig } from "../../../config/vitest.base";
 
-export default defineConfig(({ mode }) => ({
-  test: {
-    env: loadEnv(mode, process.cwd(), ""),
-  },
-  plugins: [tsconfigPaths({ projects: ["."] })],
-}));
+export default createVitestConfig();

--- a/sdks/typescript/packages/http/next/tsup.config.ts
+++ b/sdks/typescript/packages/http/next/tsup.config.ts
@@ -1,28 +1,7 @@
-import { defineConfig } from "tsup";
+import { createTsupConfig } from "../../../config/tsup.base";
 
-const baseConfig = {
-  entry: {
-    index: "src/index.ts",
-  },
-  dts: {
-    resolve: true,
-  },
-  sourcemap: true,
+export default createTsupConfig({
+  entry: { index: "src/index.ts" },
   target: "node16",
   external: ["next"],
-};
-
-export default defineConfig([
-  {
-    ...baseConfig,
-    format: "esm",
-    outDir: "dist/esm",
-    clean: true,
-  },
-  {
-    ...baseConfig,
-    format: "cjs",
-    outDir: "dist/cjs",
-    clean: false,
-  },
-]);
+});

--- a/sdks/typescript/packages/http/next/vitest.config.ts
+++ b/sdks/typescript/packages/http/next/vitest.config.ts
@@ -1,10 +1,3 @@
-import { loadEnv } from "vite";
-import { defineConfig } from "vitest/config";
-import tsconfigPaths from "vite-tsconfig-paths";
+import { createVitestConfig } from "../../../config/vitest.base";
 
-export default defineConfig(({ mode }) => ({
-  test: {
-    env: loadEnv(mode, process.cwd(), ""),
-  },
-  plugins: [tsconfigPaths({ projects: ["."] })],
-}));
+export default createVitestConfig();

--- a/sdks/typescript/packages/http/paywall/vitest.config.ts
+++ b/sdks/typescript/packages/http/paywall/vitest.config.ts
@@ -1,11 +1,5 @@
-import { loadEnv } from "vite";
-import { defineConfig } from "vitest/config";
-import tsconfigPaths from "vite-tsconfig-paths";
+import { createVitestConfig } from "../../../config/vitest.base";
 
-export default defineConfig(({ mode }) => ({
-  test: {
-    env: loadEnv(mode, process.cwd(), ""),
-    setupFiles: ["./src/test-setup.ts"],
-  },
-  plugins: [tsconfigPaths({ projects: ["."] })],
-}));
+export default createVitestConfig({
+  setupFiles: ["./src/test-setup.ts"],
+});

--- a/sdks/typescript/packages/http/quick/tsup.config.ts
+++ b/sdks/typescript/packages/http/quick/tsup.config.ts
@@ -1,30 +1,11 @@
-import { defineConfig } from "tsup";
+import { createTsupConfig } from "../../../config/tsup.base";
 
-const baseConfig = {
+export default createTsupConfig({
   entry: {
     index: "src/index.ts",
     express: "src/express.ts",
     fastify: "src/fastify.ts",
     hono: "src/hono.ts",
   },
-  dts: {
-    resolve: true,
-  },
-  sourcemap: true,
-  target: "node16" as const,
-};
-
-export default defineConfig([
-  {
-    ...baseConfig,
-    format: "esm",
-    outDir: "dist/esm",
-    clean: true,
-  },
-  {
-    ...baseConfig,
-    format: "cjs",
-    outDir: "dist/cjs",
-    clean: false,
-  },
-]);
+  target: "node16",
+});

--- a/sdks/typescript/packages/http/quick/vitest.config.ts
+++ b/sdks/typescript/packages/http/quick/vitest.config.ts
@@ -1,9 +1,3 @@
-import { defineConfig } from "vitest/config";
-import tsconfigPaths from "vite-tsconfig-paths";
+import { createVitestConfig } from "../../../config/vitest.base";
 
-export default defineConfig({
-  plugins: [tsconfigPaths()],
-  test: {
-    pool: "forks",
-  },
-});
+export default createVitestConfig({ noLoadEnv: true, pool: "forks" });

--- a/sdks/typescript/packages/http/react/tsup.config.ts
+++ b/sdks/typescript/packages/http/react/tsup.config.ts
@@ -1,29 +1,8 @@
-import { defineConfig } from 'tsup'
+import { createTsupConfig } from "../../../config/tsup.base";
 
-const baseConfig = {
-  entry: {
-    index: 'src/index.ts',
-  },
-  dts: {
-    resolve: true,
-  },
+export default createTsupConfig({
+  entry: { index: "src/index.ts" },
+  external: ["react", "react-dom"],
   splitting: false,
-  sourcemap: true,
-  external: ['react', 'react-dom'],
   treeshake: true,
-}
-
-export default defineConfig([
-  {
-    ...baseConfig,
-    format: 'esm',
-    outDir: 'dist/esm',
-    clean: true,
-  },
-  {
-    ...baseConfig,
-    format: 'cjs',
-    outDir: 'dist/cjs',
-    clean: false,
-  },
-])
+});

--- a/sdks/typescript/packages/http/react/vitest.config.ts
+++ b/sdks/typescript/packages/http/react/vitest.config.ts
@@ -1,11 +1,8 @@
-import { defineConfig } from 'vitest/config'
-import tsconfigPaths from 'vite-tsconfig-paths'
+import { createVitestConfig } from "../../../config/vitest.base";
 
-export default defineConfig({
-  plugins: [tsconfigPaths({ projects: ['.'] })],
-  test: {
-    globals: true,
-    environment: 'jsdom',
-    setupFiles: ['./src/test-setup.ts'],
-  },
-})
+export default createVitestConfig({
+  noLoadEnv: true,
+  globals: true,
+  environment: "jsdom",
+  setupFiles: ["./src/test-setup.ts"],
+});

--- a/sdks/typescript/packages/http/vue/tsup.config.ts
+++ b/sdks/typescript/packages/http/vue/tsup.config.ts
@@ -1,29 +1,8 @@
-import { defineConfig } from 'tsup'
+import { createTsupConfig } from "../../../config/tsup.base";
 
-const baseConfig = {
-  entry: {
-    index: 'src/index.ts',
-  },
-  dts: {
-    resolve: true,
-  },
+export default createTsupConfig({
+  entry: { index: "src/index.ts" },
+  external: ["vue"],
   splitting: false,
-  sourcemap: true,
-  external: ['vue'],
   treeshake: true,
-}
-
-export default defineConfig([
-  {
-    ...baseConfig,
-    format: 'esm',
-    outDir: 'dist/esm',
-    clean: true,
-  },
-  {
-    ...baseConfig,
-    format: 'cjs',
-    outDir: 'dist/cjs',
-    clean: false,
-  },
-])
+});

--- a/sdks/typescript/packages/mcp/tsup.config.ts
+++ b/sdks/typescript/packages/mcp/tsup.config.ts
@@ -1,30 +1,10 @@
-import { defineConfig } from 'tsup'
+import { createTsupConfig } from "../../config/tsup.base";
 
-const baseConfig = {
+export default createTsupConfig({
   entry: {
-    index: 'src/index.ts',
-    'server/index': 'src/server/index.ts',
-    'tools/index': 'src/tools/index.ts',
+    index: "src/index.ts",
+    "server/index": "src/server/index.ts",
+    "tools/index": "src/tools/index.ts",
   },
-  external: ['@t402/wdk', '@t402/wdk-protocol'],
-  dts: {
-    resolve: true,
-  },
-  sourcemap: true,
-  target: 'es2020',
-}
-
-export default defineConfig([
-  {
-    ...baseConfig,
-    format: 'esm',
-    outDir: 'dist/esm',
-    clean: true,
-  },
-  {
-    ...baseConfig,
-    format: 'cjs',
-    outDir: 'dist/cjs',
-    clean: false,
-  },
-])
+  external: ["@t402/wdk", "@t402/wdk-protocol"],
+});

--- a/sdks/typescript/packages/mcp/vitest.config.ts
+++ b/sdks/typescript/packages/mcp/vitest.config.ts
@@ -1,16 +1,9 @@
-import { defineConfig } from 'vitest/config'
-import tsconfigPaths from 'vite-tsconfig-paths'
+import { createVitestConfig } from "../../config/vitest.base";
 
-export default defineConfig({
-  plugins: [tsconfigPaths()],
-  test: {
-    include: ['test/**/*.test.ts'],
-    environment: 'node',
-    globals: true,
-    coverage: {
-      provider: 'v8',
-      reporter: ['text', 'json', 'html'],
-      exclude: ['node_modules/**', 'dist/**', 'test/**', '**/*.config.ts', '**/*.d.ts'],
-    },
-  },
-})
+export default createVitestConfig({
+  noLoadEnv: true,
+  globals: true,
+  environment: "node",
+  include: ["test/**/*.test.ts"],
+  coverage: true,
+});

--- a/sdks/typescript/packages/mechanisms/aptos/tsup.config.ts
+++ b/sdks/typescript/packages/mechanisms/aptos/tsup.config.ts
@@ -1,30 +1,10 @@
-import { defineConfig } from "tsup";
+import { createTsupConfig } from "../../../config/tsup.base";
 
-const baseConfig = {
+export default createTsupConfig({
   entry: {
     index: "src/index.ts",
     "exact-direct/client/index": "src/exact-direct/client/index.ts",
     "exact-direct/server/index": "src/exact-direct/server/index.ts",
     "exact-direct/facilitator/index": "src/exact-direct/facilitator/index.ts",
   },
-  dts: {
-    resolve: true,
-  },
-  sourcemap: true,
-  target: "es2020" as const,
-};
-
-export default defineConfig([
-  {
-    ...baseConfig,
-    format: "esm",
-    outDir: "dist/esm",
-    clean: true,
-  },
-  {
-    ...baseConfig,
-    format: "cjs",
-    outDir: "dist/cjs",
-    clean: false,
-  },
-]);
+});

--- a/sdks/typescript/packages/mechanisms/aptos/vitest.config.ts
+++ b/sdks/typescript/packages/mechanisms/aptos/vitest.config.ts
@@ -1,16 +1,13 @@
-import { defineConfig } from "vitest/config";
+import { createVitestConfig } from "../../../config/vitest.base";
 
-export default defineConfig({
-  test: {
-    globals: true,
-    environment: "node",
-    include: ["test/**/*.test.ts"],
-    exclude: ["test/integrations/**/*.test.ts"],
-    coverage: {
-      provider: "v8",
-      reporter: ["text", "json", "html"],
-      include: ["src/**/*.ts"],
-      exclude: ["src/**/*.d.ts"],
-    },
-  },
+export default createVitestConfig({
+  noLoadEnv: true,
+  noTsconfigPaths: true,
+  globals: true,
+  environment: "node",
+  include: ["test/**/*.test.ts"],
+  exclude: ["test/integrations/**/*.test.ts"],
+  coverage: true,
+  coverageInclude: ["src/**/*.ts"],
+  coverageExclude: ["src/**/*.d.ts"],
 });

--- a/sdks/typescript/packages/mechanisms/btc/tsup.config.ts
+++ b/sdks/typescript/packages/mechanisms/btc/tsup.config.ts
@@ -1,33 +1,13 @@
-import { defineConfig } from 'tsup'
+import { createTsupConfig } from "../../../config/tsup.base";
 
-const baseConfig = {
+export default createTsupConfig({
   entry: {
-    index: 'src/index.ts',
-    'exact/client/index': 'src/exact/client/index.ts',
-    'exact/server/index': 'src/exact/server/index.ts',
-    'exact/facilitator/index': 'src/exact/facilitator/index.ts',
-    'lightning/client/index': 'src/lightning/client/index.ts',
-    'lightning/server/index': 'src/lightning/server/index.ts',
-    'lightning/facilitator/index': 'src/lightning/facilitator/index.ts',
+    index: "src/index.ts",
+    "exact/client/index": "src/exact/client/index.ts",
+    "exact/server/index": "src/exact/server/index.ts",
+    "exact/facilitator/index": "src/exact/facilitator/index.ts",
+    "lightning/client/index": "src/lightning/client/index.ts",
+    "lightning/server/index": "src/lightning/server/index.ts",
+    "lightning/facilitator/index": "src/lightning/facilitator/index.ts",
   },
-  dts: {
-    resolve: true,
-  },
-  sourcemap: true,
-  target: 'es2020',
-}
-
-export default defineConfig([
-  {
-    ...baseConfig,
-    format: 'esm',
-    outDir: 'dist/esm',
-    clean: true,
-  },
-  {
-    ...baseConfig,
-    format: 'cjs',
-    outDir: 'dist/cjs',
-    clean: false,
-  },
-])
+});

--- a/sdks/typescript/packages/mechanisms/btc/vitest.config.ts
+++ b/sdks/typescript/packages/mechanisms/btc/vitest.config.ts
@@ -1,11 +1,3 @@
-import { loadEnv } from 'vite'
-import { defineConfig } from 'vitest/config'
-import tsconfigPaths from 'vite-tsconfig-paths'
+import { createVitestConfig } from "../../../config/vitest.base";
 
-export default defineConfig(({ mode }) => ({
-  test: {
-    env: loadEnv(mode, process.cwd(), ''),
-    exclude: ['**/node_modules/**', '**/dist/**'],
-  },
-  plugins: [tsconfigPaths({ projects: ['.'] })],
-}))
+export default createVitestConfig();

--- a/sdks/typescript/packages/mechanisms/cosmos/tsup.config.ts
+++ b/sdks/typescript/packages/mechanisms/cosmos/tsup.config.ts
@@ -1,30 +1,10 @@
-import { defineConfig } from "tsup";
+import { createTsupConfig } from "../../../config/tsup.base";
 
-const baseConfig = {
+export default createTsupConfig({
   entry: {
     index: "src/index.ts",
     "exact-direct/client/index": "src/exact-direct/client/index.ts",
     "exact-direct/server/index": "src/exact-direct/server/index.ts",
     "exact-direct/facilitator/index": "src/exact-direct/facilitator/index.ts",
   },
-  dts: {
-    resolve: true,
-  },
-  sourcemap: true,
-  target: "es2020",
-};
-
-export default defineConfig([
-  {
-    ...baseConfig,
-    format: "esm",
-    outDir: "dist/esm",
-    clean: true,
-  },
-  {
-    ...baseConfig,
-    format: "cjs",
-    outDir: "dist/cjs",
-    clean: false,
-  },
-]);
+});

--- a/sdks/typescript/packages/mechanisms/cosmos/vitest.config.ts
+++ b/sdks/typescript/packages/mechanisms/cosmos/vitest.config.ts
@@ -1,12 +1,9 @@
-import { defineConfig } from "vitest/config";
-import tsconfigPaths from "vite-tsconfig-paths";
+import { createVitestConfig } from "../../../config/vitest.base";
 
-export default defineConfig({
-  plugins: [tsconfigPaths()],
-  test: {
-    globals: true,
-    environment: "node",
-    include: ["test/unit/**/*.test.ts", "test/**/*.test.ts"],
-    exclude: ["test/integrations/**"],
-  },
+export default createVitestConfig({
+  noLoadEnv: true,
+  globals: true,
+  environment: "node",
+  include: ["test/unit/**/*.test.ts", "test/**/*.test.ts"],
+  exclude: ["test/integrations/**"],
 });

--- a/sdks/typescript/packages/mechanisms/evm-core/tsup.config.ts
+++ b/sdks/typescript/packages/mechanisms/evm-core/tsup.config.ts
@@ -1,27 +1,5 @@
-import { defineConfig } from "tsup";
+import { createTsupConfig } from "../../../config/tsup.base";
 
-const baseConfig = {
-  entry: {
-    index: "src/index.ts",
-  },
-  dts: {
-    resolve: true,
-  },
-  sourcemap: true,
-  target: "es2020",
-};
-
-export default defineConfig([
-  {
-    ...baseConfig,
-    format: "esm",
-    outDir: "dist/esm",
-    clean: true,
-  },
-  {
-    ...baseConfig,
-    format: "cjs",
-    outDir: "dist/cjs",
-    clean: false,
-  },
-]);
+export default createTsupConfig({
+  entry: { index: "src/index.ts" },
+});

--- a/sdks/typescript/packages/mechanisms/evm-core/vitest.config.ts
+++ b/sdks/typescript/packages/mechanisms/evm-core/vitest.config.ts
@@ -1,12 +1,8 @@
-import { defineConfig } from "vitest/config";
-import tsconfigPaths from "vite-tsconfig-paths";
+import { createVitestConfig } from "../../../config/vitest.base";
 
-export default defineConfig({
-  plugins: [tsconfigPaths({ projects: ["."] })],
-  test: {
-    globals: true,
-    environment: "node",
-    include: ["src/**/*.test.ts"],
-    exclude: ["**/node_modules/**", "**/dist/**"],
-  },
+export default createVitestConfig({
+  noLoadEnv: true,
+  globals: true,
+  environment: "node",
+  include: ["src/**/*.test.ts"],
 });

--- a/sdks/typescript/packages/mechanisms/evm/tsup.config.ts
+++ b/sdks/typescript/packages/mechanisms/evm/tsup.config.ts
@@ -1,6 +1,6 @@
-import { defineConfig } from "tsup";
+import { createTsupConfig } from "../../../config/tsup.base";
 
-const baseConfig = {
+export default createTsupConfig({
   entry: {
     index: "src/index.ts",
     "v1/index": "src/v1/index.ts",
@@ -23,24 +23,4 @@ const baseConfig = {
     "upto/client/index": "src/upto/client/index.ts",
     "upto/index": "src/upto/index.ts",
   },
-  dts: {
-    resolve: true,
-  },
-  sourcemap: true,
-  target: "es2020",
-};
-
-export default defineConfig([
-  {
-    ...baseConfig,
-    format: "esm",
-    outDir: "dist/esm",
-    clean: true,
-  },
-  {
-    ...baseConfig,
-    format: "cjs",
-    outDir: "dist/cjs",
-    clean: false,
-  },
-]);
+});

--- a/sdks/typescript/packages/mechanisms/evm/vitest.config.ts
+++ b/sdks/typescript/packages/mechanisms/evm/vitest.config.ts
@@ -1,15 +1,3 @@
-import { loadEnv } from "vite";
-import { defineConfig } from "vitest/config";
-import tsconfigPaths from "vite-tsconfig-paths";
+import { createVitestConfig } from "../../../config/vitest.base";
 
-export default defineConfig(({ mode }) => ({
-  test: {
-    env: loadEnv(mode, process.cwd(), ""),
-    exclude: [
-      "**/node_modules/**",
-      "**/dist/**",
-      "**/test/integrations/**", // Exclude integration tests from default run
-    ],
-  },
-  plugins: [tsconfigPaths({ projects: ["."] })],
-}));
+export default createVitestConfig({ excludeIntegration: true });

--- a/sdks/typescript/packages/mechanisms/near/tsup.config.ts
+++ b/sdks/typescript/packages/mechanisms/near/tsup.config.ts
@@ -1,6 +1,6 @@
-import { defineConfig } from "tsup";
+import { createTsupConfig } from "../../../config/tsup.base";
 
-const baseConfig = {
+export default createTsupConfig({
   entry: {
     index: "src/index.ts",
     "exact-direct/client/index": "src/exact-direct/client/index.ts",
@@ -8,24 +8,4 @@ const baseConfig = {
     "exact-direct/facilitator/index": "src/exact-direct/facilitator/index.ts",
     "upto/index": "src/upto/index.ts",
   },
-  dts: {
-    resolve: true,
-  },
-  sourcemap: true,
-  target: "es2020",
-};
-
-export default defineConfig([
-  {
-    ...baseConfig,
-    format: "esm",
-    outDir: "dist/esm",
-    clean: true,
-  },
-  {
-    ...baseConfig,
-    format: "cjs",
-    outDir: "dist/cjs",
-    clean: false,
-  },
-]);
+});

--- a/sdks/typescript/packages/mechanisms/near/vitest.config.ts
+++ b/sdks/typescript/packages/mechanisms/near/vitest.config.ts
@@ -1,12 +1,9 @@
-import { defineConfig } from "vitest/config";
-import tsconfigPaths from "vite-tsconfig-paths";
+import { createVitestConfig } from "../../../config/vitest.base";
 
-export default defineConfig({
-  plugins: [tsconfigPaths()],
-  test: {
-    globals: true,
-    environment: "node",
-    include: ["test/unit/**/*.test.ts", "test/**/*.test.ts"],
-    exclude: ["test/integrations/**"],
-  },
+export default createVitestConfig({
+  noLoadEnv: true,
+  globals: true,
+  environment: "node",
+  include: ["test/unit/**/*.test.ts", "test/**/*.test.ts"],
+  exclude: ["test/integrations/**"],
 });

--- a/sdks/typescript/packages/mechanisms/polkadot/tsup.config.ts
+++ b/sdks/typescript/packages/mechanisms/polkadot/tsup.config.ts
@@ -1,30 +1,10 @@
-import { defineConfig } from "tsup";
+import { createTsupConfig } from "../../../config/tsup.base";
 
-const baseConfig = {
+export default createTsupConfig({
   entry: {
     index: "src/index.ts",
     "exact-direct/client/index": "src/exact-direct/client/index.ts",
     "exact-direct/server/index": "src/exact-direct/server/index.ts",
     "exact-direct/facilitator/index": "src/exact-direct/facilitator/index.ts",
   },
-  dts: {
-    resolve: true,
-  },
-  sourcemap: true,
-  target: "es2020" as const,
-};
-
-export default defineConfig([
-  {
-    ...baseConfig,
-    format: "esm",
-    outDir: "dist/esm",
-    clean: true,
-  },
-  {
-    ...baseConfig,
-    format: "cjs",
-    outDir: "dist/cjs",
-    clean: false,
-  },
-]);
+});

--- a/sdks/typescript/packages/mechanisms/polkadot/vitest.config.ts
+++ b/sdks/typescript/packages/mechanisms/polkadot/vitest.config.ts
@@ -1,16 +1,13 @@
-import { defineConfig } from "vitest/config";
+import { createVitestConfig } from "../../../config/vitest.base";
 
-export default defineConfig({
-  test: {
-    globals: true,
-    environment: "node",
-    include: ["test/**/*.test.ts"],
-    exclude: ["test/integrations/**/*.test.ts"],
-    coverage: {
-      provider: "v8",
-      reporter: ["text", "json", "html"],
-      include: ["src/**/*.ts"],
-      exclude: ["src/**/*.d.ts"],
-    },
-  },
+export default createVitestConfig({
+  noLoadEnv: true,
+  noTsconfigPaths: true,
+  globals: true,
+  environment: "node",
+  include: ["test/**/*.test.ts"],
+  exclude: ["test/integrations/**/*.test.ts"],
+  coverage: true,
+  coverageInclude: ["src/**/*.ts"],
+  coverageExclude: ["src/**/*.d.ts"],
 });

--- a/sdks/typescript/packages/mechanisms/spark/tsup.config.ts
+++ b/sdks/typescript/packages/mechanisms/spark/tsup.config.ts
@@ -1,5 +1,6 @@
-import { defineConfig } from "tsup";
-export default defineConfig([
-  { entry: ["src/index.ts"], format: ["esm"], dts: true, outDir: "dist/esm", sourcemap: true },
-  { entry: ["src/index.ts"], format: ["cjs"], dts: true, outDir: "dist/cjs", sourcemap: true },
-]);
+import { createTsupConfig } from "../../../config/tsup.base";
+
+export default createTsupConfig({
+  entry: ["src/index.ts"],
+  simpleDts: true,
+});

--- a/sdks/typescript/packages/mechanisms/spark/vitest.config.ts
+++ b/sdks/typescript/packages/mechanisms/spark/vitest.config.ts
@@ -1,2 +1,8 @@
-import { defineConfig } from "vitest/config";
-export default defineConfig({ test: { pool: "forks", include: ["test/**/*.test.ts"] } });
+import { createVitestConfig } from "../../../config/vitest.base";
+
+export default createVitestConfig({
+  noLoadEnv: true,
+  noTsconfigPaths: true,
+  pool: "forks",
+  include: ["test/**/*.test.ts"],
+});

--- a/sdks/typescript/packages/mechanisms/stacks/tsup.config.ts
+++ b/sdks/typescript/packages/mechanisms/stacks/tsup.config.ts
@@ -1,30 +1,10 @@
-import { defineConfig } from "tsup";
+import { createTsupConfig } from "../../../config/tsup.base";
 
-const baseConfig = {
+export default createTsupConfig({
   entry: {
     index: "src/index.ts",
     "exact-direct/client/index": "src/exact-direct/client/index.ts",
     "exact-direct/server/index": "src/exact-direct/server/index.ts",
     "exact-direct/facilitator/index": "src/exact-direct/facilitator/index.ts",
   },
-  dts: {
-    resolve: true,
-  },
-  sourcemap: true,
-  target: "es2020" as const,
-};
-
-export default defineConfig([
-  {
-    ...baseConfig,
-    format: "esm",
-    outDir: "dist/esm",
-    clean: true,
-  },
-  {
-    ...baseConfig,
-    format: "cjs",
-    outDir: "dist/cjs",
-    clean: false,
-  },
-]);
+});

--- a/sdks/typescript/packages/mechanisms/stacks/vitest.config.ts
+++ b/sdks/typescript/packages/mechanisms/stacks/vitest.config.ts
@@ -1,16 +1,13 @@
-import { defineConfig } from "vitest/config";
+import { createVitestConfig } from "../../../config/vitest.base";
 
-export default defineConfig({
-  test: {
-    globals: true,
-    environment: "node",
-    include: ["test/**/*.test.ts"],
-    exclude: ["test/integrations/**/*.test.ts"],
-    coverage: {
-      provider: "v8",
-      reporter: ["text", "json", "html"],
-      include: ["src/**/*.ts"],
-      exclude: ["src/**/*.d.ts"],
-    },
-  },
+export default createVitestConfig({
+  noLoadEnv: true,
+  noTsconfigPaths: true,
+  globals: true,
+  environment: "node",
+  include: ["test/**/*.test.ts"],
+  exclude: ["test/integrations/**/*.test.ts"],
+  coverage: true,
+  coverageInclude: ["src/**/*.ts"],
+  coverageExclude: ["src/**/*.d.ts"],
 });

--- a/sdks/typescript/packages/mechanisms/stellar/tsup.config.ts
+++ b/sdks/typescript/packages/mechanisms/stellar/tsup.config.ts
@@ -1,30 +1,10 @@
-import { defineConfig } from 'tsup'
+import { createTsupConfig } from "../../../config/tsup.base";
 
-const baseConfig = {
+export default createTsupConfig({
   entry: {
-    index: 'src/index.ts',
-    'exact/client/index': 'src/exact/client/index.ts',
-    'exact/server/index': 'src/exact/server/index.ts',
-    'exact/facilitator/index': 'src/exact/facilitator/index.ts',
+    index: "src/index.ts",
+    "exact/client/index": "src/exact/client/index.ts",
+    "exact/server/index": "src/exact/server/index.ts",
+    "exact/facilitator/index": "src/exact/facilitator/index.ts",
   },
-  dts: {
-    resolve: true,
-  },
-  sourcemap: true,
-  target: 'es2020',
-}
-
-export default defineConfig([
-  {
-    ...baseConfig,
-    format: 'esm',
-    outDir: 'dist/esm',
-    clean: true,
-  },
-  {
-    ...baseConfig,
-    format: 'cjs',
-    outDir: 'dist/cjs',
-    clean: false,
-  },
-])
+});

--- a/sdks/typescript/packages/mechanisms/stellar/vitest.config.ts
+++ b/sdks/typescript/packages/mechanisms/stellar/vitest.config.ts
@@ -1,15 +1,3 @@
-import { loadEnv } from 'vite'
-import { defineConfig } from 'vitest/config'
-import tsconfigPaths from 'vite-tsconfig-paths'
+import { createVitestConfig } from "../../../config/vitest.base";
 
-export default defineConfig(({ mode }) => ({
-  test: {
-    env: loadEnv(mode, process.cwd(), ''),
-    exclude: [
-      '**/node_modules/**',
-      '**/dist/**',
-      '**/test/integrations/**', // Exclude integration tests from default run
-    ],
-  },
-  plugins: [tsconfigPaths({ projects: ['.'] })],
-}))
+export default createVitestConfig({ excludeIntegration: true });

--- a/sdks/typescript/packages/mechanisms/svm/tsup.config.ts
+++ b/sdks/typescript/packages/mechanisms/svm/tsup.config.ts
@@ -1,6 +1,6 @@
-import { defineConfig } from "tsup";
+import { createTsupConfig } from "../../../config/tsup.base";
 
-const baseConfig = {
+export default createTsupConfig({
   entry: {
     index: "src/index.ts",
     "v1/index": "src/v1/index.ts",
@@ -11,24 +11,4 @@ const baseConfig = {
     "exact/v1/facilitator/index": "src/exact/v1/facilitator/index.ts",
     "upto/index": "src/upto/index.ts",
   },
-  dts: {
-    resolve: true,
-  },
-  sourcemap: true,
-  target: "es2020",
-};
-
-export default defineConfig([
-  {
-    ...baseConfig,
-    format: "esm",
-    outDir: "dist/esm",
-    clean: true,
-  },
-  {
-    ...baseConfig,
-    format: "cjs",
-    outDir: "dist/cjs",
-    clean: false,
-  },
-]);
+});

--- a/sdks/typescript/packages/mechanisms/svm/vitest.config.ts
+++ b/sdks/typescript/packages/mechanisms/svm/vitest.config.ts
@@ -1,15 +1,3 @@
-import { loadEnv } from "vite";
-import { defineConfig } from "vitest/config";
-import tsconfigPaths from "vite-tsconfig-paths";
+import { createVitestConfig } from "../../../config/vitest.base";
 
-export default defineConfig(({ mode }) => ({
-  test: {
-    env: loadEnv(mode, process.cwd(), ""),
-    exclude: [
-      "**/node_modules/**",
-      "**/dist/**",
-      "**/test/integrations/**", // Exclude integration tests from default run
-    ],
-  },
-  plugins: [tsconfigPaths({ projects: ["."] })],
-}));
+export default createVitestConfig({ excludeIntegration: true });

--- a/sdks/typescript/packages/mechanisms/tezos/tsup.config.ts
+++ b/sdks/typescript/packages/mechanisms/tezos/tsup.config.ts
@@ -1,30 +1,10 @@
-import { defineConfig } from "tsup";
+import { createTsupConfig } from "../../../config/tsup.base";
 
-const baseConfig = {
+export default createTsupConfig({
   entry: {
     index: "src/index.ts",
     "exact-direct/client/index": "src/exact-direct/client/index.ts",
     "exact-direct/server/index": "src/exact-direct/server/index.ts",
     "exact-direct/facilitator/index": "src/exact-direct/facilitator/index.ts",
   },
-  dts: {
-    resolve: true,
-  },
-  sourcemap: true,
-  target: "es2020" as const,
-};
-
-export default defineConfig([
-  {
-    ...baseConfig,
-    format: "esm",
-    outDir: "dist/esm",
-    clean: true,
-  },
-  {
-    ...baseConfig,
-    format: "cjs",
-    outDir: "dist/cjs",
-    clean: false,
-  },
-]);
+});

--- a/sdks/typescript/packages/mechanisms/tezos/vitest.config.ts
+++ b/sdks/typescript/packages/mechanisms/tezos/vitest.config.ts
@@ -1,16 +1,13 @@
-import { defineConfig } from "vitest/config";
+import { createVitestConfig } from "../../../config/vitest.base";
 
-export default defineConfig({
-  test: {
-    globals: true,
-    environment: "node",
-    include: ["test/**/*.test.ts"],
-    exclude: ["test/integrations/**/*.test.ts"],
-    coverage: {
-      provider: "v8",
-      reporter: ["text", "json", "html"],
-      include: ["src/**/*.ts"],
-      exclude: ["src/**/*.d.ts"],
-    },
-  },
+export default createVitestConfig({
+  noLoadEnv: true,
+  noTsconfigPaths: true,
+  globals: true,
+  environment: "node",
+  include: ["test/**/*.test.ts"],
+  exclude: ["test/integrations/**/*.test.ts"],
+  coverage: true,
+  coverageInclude: ["src/**/*.ts"],
+  coverageExclude: ["src/**/*.d.ts"],
 });

--- a/sdks/typescript/packages/mechanisms/ton/tsup.config.ts
+++ b/sdks/typescript/packages/mechanisms/ton/tsup.config.ts
@@ -1,31 +1,11 @@
-import { defineConfig } from 'tsup'
+import { createTsupConfig } from "../../../config/tsup.base";
 
-const baseConfig = {
+export default createTsupConfig({
   entry: {
-    index: 'src/index.ts',
-    'exact/client/index': 'src/exact/client/index.ts',
-    'exact/server/index': 'src/exact/server/index.ts',
-    'exact/facilitator/index': 'src/exact/facilitator/index.ts',
-    'upto/index': 'src/upto/index.ts',
+    index: "src/index.ts",
+    "exact/client/index": "src/exact/client/index.ts",
+    "exact/server/index": "src/exact/server/index.ts",
+    "exact/facilitator/index": "src/exact/facilitator/index.ts",
+    "upto/index": "src/upto/index.ts",
   },
-  dts: {
-    resolve: true,
-  },
-  sourcemap: true,
-  target: 'es2020',
-}
-
-export default defineConfig([
-  {
-    ...baseConfig,
-    format: 'esm',
-    outDir: 'dist/esm',
-    clean: true,
-  },
-  {
-    ...baseConfig,
-    format: 'cjs',
-    outDir: 'dist/cjs',
-    clean: false,
-  },
-])
+});

--- a/sdks/typescript/packages/mechanisms/ton/vitest.config.ts
+++ b/sdks/typescript/packages/mechanisms/ton/vitest.config.ts
@@ -1,15 +1,3 @@
-import { loadEnv } from 'vite'
-import { defineConfig } from 'vitest/config'
-import tsconfigPaths from 'vite-tsconfig-paths'
+import { createVitestConfig } from "../../../config/vitest.base";
 
-export default defineConfig(({ mode }) => ({
-  test: {
-    env: loadEnv(mode, process.cwd(), ''),
-    exclude: [
-      '**/node_modules/**',
-      '**/dist/**',
-      '**/test/integrations/**', // Exclude integration tests from default run
-    ],
-  },
-  plugins: [tsconfigPaths({ projects: ['.'] })],
-}))
+export default createVitestConfig({ excludeIntegration: true });

--- a/sdks/typescript/packages/mechanisms/tron/tsup.config.ts
+++ b/sdks/typescript/packages/mechanisms/tron/tsup.config.ts
@@ -1,31 +1,11 @@
-import { defineConfig } from 'tsup'
+import { createTsupConfig } from "../../../config/tsup.base";
 
-const baseConfig = {
+export default createTsupConfig({
   entry: {
-    index: 'src/index.ts',
-    'exact/client/index': 'src/exact/client/index.ts',
-    'exact/server/index': 'src/exact/server/index.ts',
-    'exact/facilitator/index': 'src/exact/facilitator/index.ts',
-    'upto/index': 'src/upto/index.ts',
+    index: "src/index.ts",
+    "exact/client/index": "src/exact/client/index.ts",
+    "exact/server/index": "src/exact/server/index.ts",
+    "exact/facilitator/index": "src/exact/facilitator/index.ts",
+    "upto/index": "src/upto/index.ts",
   },
-  dts: {
-    resolve: true,
-  },
-  sourcemap: true,
-  target: 'es2020',
-}
-
-export default defineConfig([
-  {
-    ...baseConfig,
-    format: 'esm',
-    outDir: 'dist/esm',
-    clean: true,
-  },
-  {
-    ...baseConfig,
-    format: 'cjs',
-    outDir: 'dist/cjs',
-    clean: false,
-  },
-])
+});

--- a/sdks/typescript/packages/mechanisms/tron/vitest.config.ts
+++ b/sdks/typescript/packages/mechanisms/tron/vitest.config.ts
@@ -1,15 +1,3 @@
-import { loadEnv } from 'vite'
-import { defineConfig } from 'vitest/config'
-import tsconfigPaths from 'vite-tsconfig-paths'
+import { createVitestConfig } from "../../../config/vitest.base";
 
-export default defineConfig(({ mode }) => ({
-  test: {
-    env: loadEnv(mode, process.cwd(), ''),
-    exclude: [
-      '**/node_modules/**',
-      '**/dist/**',
-      '**/test/integrations/**', // Exclude integration tests from default run
-    ],
-  },
-  plugins: [tsconfigPaths({ projects: ['.'] })],
-}))
+export default createVitestConfig({ excludeIntegration: true });

--- a/sdks/typescript/packages/observability/tsup.config.ts
+++ b/sdks/typescript/packages/observability/tsup.config.ts
@@ -1,27 +1,5 @@
-import { defineConfig } from "tsup";
+import { createTsupConfig } from "../../config/tsup.base";
 
-const baseConfig = {
-  entry: {
-    index: "src/index.ts",
-  },
-  dts: {
-    resolve: true,
-  },
-  sourcemap: true,
-  target: "es2020",
-};
-
-export default defineConfig([
-  {
-    ...baseConfig,
-    format: "esm",
-    outDir: "dist/esm",
-    clean: true,
-  },
-  {
-    ...baseConfig,
-    format: "cjs",
-    outDir: "dist/cjs",
-    clean: false,
-  },
-]);
+export default createTsupConfig({
+  entry: { index: "src/index.ts" },
+});

--- a/sdks/typescript/packages/observability/vitest.config.ts
+++ b/sdks/typescript/packages/observability/vitest.config.ts
@@ -1,16 +1,3 @@
-import { loadEnv } from "vite";
-import { defineConfig } from "vitest/config";
-import tsconfigPaths from "vite-tsconfig-paths";
+import { createVitestConfig } from "../../config/vitest.base";
 
-export default defineConfig(({ mode }) => ({
-  test: {
-    env: loadEnv(mode, process.cwd(), ""),
-    pool: "forks",
-    coverage: {
-      provider: "v8",
-      reporter: ["text", "json", "html"],
-      exclude: ["node_modules/**", "dist/**", "test/**", "**/*.config.ts", "**/*.d.ts"],
-    },
-  },
-  plugins: [tsconfigPaths({ projects: ["."] })],
-}));
+export default createVitestConfig({ coverage: true, pool: "forks" });

--- a/sdks/typescript/packages/policy/tsup.config.ts
+++ b/sdks/typescript/packages/policy/tsup.config.ts
@@ -1,27 +1,5 @@
-import { defineConfig } from "tsup";
+import { createTsupConfig } from "../../config/tsup.base";
 
-const baseConfig = {
-  entry: {
-    index: "src/index.ts",
-  },
-  dts: {
-    resolve: true,
-  },
-  sourcemap: true,
-  target: "es2020",
-};
-
-export default defineConfig([
-  {
-    ...baseConfig,
-    format: "esm",
-    outDir: "dist/esm",
-    clean: true,
-  },
-  {
-    ...baseConfig,
-    format: "cjs",
-    outDir: "dist/cjs",
-    clean: false,
-  },
-]);
+export default createTsupConfig({
+  entry: { index: "src/index.ts" },
+});

--- a/sdks/typescript/packages/policy/vitest.config.ts
+++ b/sdks/typescript/packages/policy/vitest.config.ts
@@ -1,16 +1,3 @@
-import { loadEnv } from "vite";
-import { defineConfig } from "vitest/config";
-import tsconfigPaths from "vite-tsconfig-paths";
+import { createVitestConfig } from "../../config/vitest.base";
 
-export default defineConfig(({ mode }) => ({
-  test: {
-    env: loadEnv(mode, process.cwd(), ""),
-    pool: "forks",
-    coverage: {
-      provider: "v8",
-      reporter: ["text", "json", "html"],
-      exclude: ["node_modules/**", "dist/**", "test/**", "**/*.config.ts", "**/*.d.ts"],
-    },
-  },
-  plugins: [tsconfigPaths({ projects: ["."] })],
-}));
+export default createVitestConfig({ coverage: true, pool: "forks" });

--- a/sdks/typescript/packages/wdk-facilitator/tsup.config.ts
+++ b/sdks/typescript/packages/wdk-facilitator/tsup.config.ts
@@ -1,18 +1,6 @@
-import { defineConfig } from "tsup";
+import { createTsupConfig } from "../../config/tsup.base";
 
-export default defineConfig([
-  {
-    entry: ["src/index.ts"],
-    format: ["esm"],
-    dts: true,
-    outDir: "dist/esm",
-    sourcemap: true,
-  },
-  {
-    entry: ["src/index.ts"],
-    format: ["cjs"],
-    dts: true,
-    outDir: "dist/cjs",
-    sourcemap: true,
-  },
-]);
+export default createTsupConfig({
+  entry: ["src/index.ts"],
+  simpleDts: true,
+});

--- a/sdks/typescript/packages/wdk-facilitator/vitest.config.ts
+++ b/sdks/typescript/packages/wdk-facilitator/vitest.config.ts
@@ -1,8 +1,8 @@
-import { defineConfig } from "vitest/config";
+import { createVitestConfig } from "../../config/vitest.base";
 
-export default defineConfig({
-  test: {
-    pool: "forks",
-    include: ["test/**/*.test.ts"],
-  },
+export default createVitestConfig({
+  noLoadEnv: true,
+  noTsconfigPaths: true,
+  pool: "forks",
+  include: ["test/**/*.test.ts"],
 });

--- a/sdks/typescript/packages/wdk-fiat/tsup.config.ts
+++ b/sdks/typescript/packages/wdk-fiat/tsup.config.ts
@@ -1,5 +1,6 @@
-import { defineConfig } from "tsup";
-export default defineConfig([
-  { entry: ["src/index.ts"], format: ["esm"], dts: true, outDir: "dist/esm", sourcemap: true },
-  { entry: ["src/index.ts"], format: ["cjs"], dts: true, outDir: "dist/cjs", sourcemap: true },
-]);
+import { createTsupConfig } from "../../config/tsup.base";
+
+export default createTsupConfig({
+  entry: ["src/index.ts"],
+  simpleDts: true,
+});

--- a/sdks/typescript/packages/wdk-fiat/vitest.config.ts
+++ b/sdks/typescript/packages/wdk-fiat/vitest.config.ts
@@ -1,2 +1,8 @@
-import { defineConfig } from "vitest/config";
-export default defineConfig({ test: { pool: "forks", include: ["test/**/*.test.ts"] } });
+import { createVitestConfig } from "../../config/vitest.base";
+
+export default createVitestConfig({
+  noLoadEnv: true,
+  noTsconfigPaths: true,
+  pool: "forks",
+  include: ["test/**/*.test.ts"],
+});

--- a/sdks/typescript/packages/wdk-lending/tsup.config.ts
+++ b/sdks/typescript/packages/wdk-lending/tsup.config.ts
@@ -1,5 +1,6 @@
-import { defineConfig } from "tsup";
-export default defineConfig([
-  { entry: ["src/index.ts"], format: ["esm"], dts: true, outDir: "dist/esm", sourcemap: true },
-  { entry: ["src/index.ts"], format: ["cjs"], dts: true, outDir: "dist/cjs", sourcemap: true },
-]);
+import { createTsupConfig } from "../../config/tsup.base";
+
+export default createTsupConfig({
+  entry: ["src/index.ts"],
+  simpleDts: true,
+});

--- a/sdks/typescript/packages/wdk-lending/vitest.config.ts
+++ b/sdks/typescript/packages/wdk-lending/vitest.config.ts
@@ -1,2 +1,8 @@
-import { defineConfig } from "vitest/config";
-export default defineConfig({ test: { pool: "forks", include: ["test/**/*.test.ts"] } });
+import { createVitestConfig } from "../../config/vitest.base";
+
+export default createVitestConfig({
+  noLoadEnv: true,
+  noTsconfigPaths: true,
+  pool: "forks",
+  include: ["test/**/*.test.ts"],
+});

--- a/sdks/typescript/packages/wdk-swap-jupiter/tsup.config.ts
+++ b/sdks/typescript/packages/wdk-swap-jupiter/tsup.config.ts
@@ -1,5 +1,6 @@
-import { defineConfig } from "tsup";
-export default defineConfig([
-  { entry: ["src/index.ts"], format: ["esm"], dts: true, outDir: "dist/esm", sourcemap: true },
-  { entry: ["src/index.ts"], format: ["cjs"], dts: true, outDir: "dist/cjs", sourcemap: true },
-]);
+import { createTsupConfig } from "../../config/tsup.base";
+
+export default createTsupConfig({
+  entry: ["src/index.ts"],
+  simpleDts: true,
+});

--- a/sdks/typescript/packages/wdk-swap-jupiter/vitest.config.ts
+++ b/sdks/typescript/packages/wdk-swap-jupiter/vitest.config.ts
@@ -1,2 +1,8 @@
-import { defineConfig } from "vitest/config";
-export default defineConfig({ test: { pool: "forks", include: ["test/**/*.test.ts"] } });
+import { createVitestConfig } from "../../config/vitest.base";
+
+export default createVitestConfig({
+  noLoadEnv: true,
+  noTsconfigPaths: true,
+  pool: "forks",
+  include: ["test/**/*.test.ts"],
+});


### PR DESCRIPTION
## Summary

- Introduce `createTsupConfig()` and `createVitestConfig()` factory functions in `sdks/typescript/config/`
- Convert 71 config files (36 tsup + 35 vitest) to use shared factories, reducing ~1,200 lines of duplicated boilerplate
- Net reduction: **-611 lines** of config code across 73 files

## Motivation

Every TS package had its own hand-written tsup.config.ts (~25 lines) and vitest.config.ts (~10-15 lines) with near-identical boilerplate. Adding a new package required copy-pasting and adjusting these configs. A single change (e.g., build target) required editing 37+ files.

## What changed

| File | Purpose |
|------|---------|
| `config/tsup.base.ts` | Factory for dual ESM+CJS builds with `dts`, `sourcemap`, `target`, `external`, `banner`, `explicitExtensions` options |
| `config/vitest.base.ts` | Factory for vitest configs with `loadEnv`, `tsconfigPaths`, `coverage`, `pool`, `globals`, `setupFiles` options |

### Coverage
- **tsup**: 36/37 packages converted (paywall excluded — unique treeshake preset + per-format splitting)
- **vitest**: 35/37 packages converted (cli excluded — missing vite dep; vue excluded — needs @vitejs/plugin-vue)

### Before (typical mechanism package)
```ts
// tsup.config.ts — 30 lines
import { defineConfig } from "tsup";
const baseConfig = { entry: { ... }, dts: { resolve: true }, sourcemap: true, target: "es2020" };
export default defineConfig([
  { ...baseConfig, format: "esm", outDir: "dist/esm", clean: true },
  { ...baseConfig, format: "cjs", outDir: "dist/cjs", clean: false },
]);
```

### After
```ts
// tsup.config.ts — 5 lines
import { createTsupConfig } from "../../../config/tsup.base";
export default createTsupConfig({
  entry: { index: "src/index.ts", "exact/client/index": "src/exact/client/index.ts" },
});
```

## Test plan

- [x] `pnpm build` — 37/37 packages build successfully
- [x] `pnpm test` — 74/74 tasks pass (build + test), ~3,675 tests, zero regression
- [x] Verified edge cases: a2a (explicitExtensions), cli (banner + esmEntry), erc8004 (simpleDts), react/vue (treeshake + external)